### PR TITLE
Add Kafka to Redshift ETL pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,43 @@ docker exec -it devops_kafka-2_1 kafka-console-producer  --bootstrap-server loca
 docker exec -it devops_kafka-2_1 kafka-console-consumer  --bootstrap-server localhost:9092 --topic ishwar-topic —from-beginning
 
 ```
+
+## Kafka to Redshift ETL
+
+This repository includes a pipeline that consumes messages from Kafka and loads them into an Amazon Redshift table.
+
+### Prerequisites
+
+1. A running Kafka cluster. The existing docker-compose setup can be used.
+2. An Amazon Redshift cluster with a table created to receive data.
+3. Environment variables configured:
+   - `BOOTSTRAP_SERVERS`
+   - `KAFKA_TOPIC`
+   - `REDSHIFT_HOST`
+   - `REDSHIFT_PORT` (optional, defaults to 5439)
+   - `REDSHIFT_USER`
+   - `REDSHIFT_PASSWORD`
+   - `REDSHIFT_DB`
+   - `REDSHIFT_TABLE`
+
+### Running the Pipeline
+
+Install dependencies:
+
+```bash
+pip install -r req.txt
+```
+
+Start producing messages using the FastAPI application:
+
+```bash
+uvicorn admin_cmd:app --reload
+```
+
+Run the ETL consumer that writes to Redshift:
+
+```bash
+python -m etl
+```
+
+Messages published to the configured Kafka topic are transformed and inserted into the specified Redshift table.

--- a/etl/__init__.py
+++ b/etl/__init__.py
@@ -1,0 +1,1 @@
+"""ETL package for moving data from Kafka to Redshift."""

--- a/etl/__main__.py
+++ b/etl/__main__.py
@@ -1,0 +1,13 @@
+"""Entry point for running the Kafka to Redshift ETL pipeline."""
+
+from .pipeline import KafkaToRedshiftETL
+
+
+def main():
+    """Run the ETL pipeline."""
+    pipeline = KafkaToRedshiftETL()
+    pipeline.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/etl/pipeline.py
+++ b/etl/pipeline.py
@@ -1,0 +1,47 @@
+"""Module providing a Kafka to Redshift ETL pipeline."""
+
+import json
+import os
+from kafka import KafkaConsumer
+import psycopg2
+
+
+class KafkaToRedshiftETL:
+    """Pipeline extracting messages from Kafka and loading them into Redshift."""
+
+    def __init__(self):
+        """Initialize consumer and Redshift connection using environment variables."""
+        self.consumer = KafkaConsumer(
+            os.environ["KAFKA_TOPIC"],
+            bootstrap_servers=os.environ["BOOTSTRAP_SERVERS"],
+            value_deserializer=lambda m: json.loads(m.decode("utf-8")),
+        )
+        self.connection = psycopg2.connect(
+            host=os.environ["REDSHIFT_HOST"],
+            port=os.environ.get("REDSHIFT_PORT", "5439"),
+            user=os.environ["REDSHIFT_USER"],
+            password=os.environ["REDSHIFT_PASSWORD"],
+            database=os.environ["REDSHIFT_DB"],
+        )
+        self.table = os.environ["REDSHIFT_TABLE"]
+
+    def transform(self, record):
+        """Transform records before loading."""
+        return {k: v.upper() if isinstance(v, str) else v for k, v in record.items()}
+
+    def load(self, record):
+        """Insert transformed record into Redshift."""
+        columns = ",".join(record.keys())
+        placeholders = ",".join(["%s"] * len(record))
+        values = list(record.values())
+        with self.connection.cursor() as cursor:
+            cursor.execute(
+                f"insert into {self.table} ({columns}) values ({placeholders})", values
+            )
+        self.connection.commit()
+
+    def run(self):
+        """Consume messages from Kafka and load them into Redshift."""
+        for message in self.consumer:
+            transformed = self.transform(message.value)
+            self.load(transformed)

--- a/req.txt
+++ b/req.txt
@@ -4,3 +4,4 @@ python-dotenv
 flake8
 black
 pylint
+psycopg2-binary


### PR DESCRIPTION
## Summary
- add Kafka to Redshift ETL package and entry point
- document end-to-end setup in README
- include psycopg2-binary in requirements

## Testing
- `pip install -r req.txt` *(fails: Could not find a version that satisfies the requirement kafka-python)*
- `flake8 etl` *(fails: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac40336c4483338dfa04a91874ef52